### PR TITLE
Implement name_scan

### DIFF
--- a/applications/libcoind/libcoind.cpp
+++ b/applications/libcoind/libcoind.cpp
@@ -177,6 +177,7 @@ int main(int argc, char* argv[])
         if (conf.chain().adhere_names()) {
             server.registerMethod(method_ptr(new NameShow(node)));
             server.registerMethod(method_ptr(new NameHistory(node)));
+            server.registerMethod(method_ptr(new NameScan(node)));
         }
         
         /// The Pool enables you to run a backend for a miner, i.e. your private pool, it also enables you to participate in the "Name of Pool"

--- a/include/coinChain/BlockChain.h
+++ b/include/coinChain/BlockChain.h
@@ -269,10 +269,10 @@ public:
       return (count == 0 || count <= getExpirationCount (treeCount));
     }
 
-    /// NameCoin: query for full row in Names table
+    /// NameCoin: query for data in the Names table
     NameDbRow getNameRow(const std::string& name) const;
-    /// NameCoin: query for all rows in Names table for a given name
     std::vector<NameDbRow> getNameHistory(const std::string& name) const;
+    std::vector<NameDbRow> getNameScan(const std::string& start, unsigned cnt) const;
     
     /// Get the locator for the best index
     const BlockLocator& getBestLocator() const;

--- a/include/coinName/NameGetRPC.h
+++ b/include/coinName/NameGetRPC.h
@@ -118,4 +118,37 @@ public:
 
 };
 
+/* ************************************************************************** */
+/* name_scan implementation.  */
+
+/**
+ * Implementation of the name_scan method to list (a subset of) all known
+ * names (but only with their latest status).
+ */
+class COINNAME_EXPORT NameScan : public NameGetMethod
+{
+
+public:
+
+  /**
+   * Construct it for the given node.
+   * @param n Node to use.
+   */
+  explicit inline
+  NameScan (Node& n)
+    : NameGetMethod(n)
+  {
+    setName ("name_scan");
+  }
+
+  /**
+   * Perform the call.
+   * @param params Parameters given to call.
+   * @param fHelp Help requested?
+   * @return JSON result.
+   */
+  json_spirit::Value operator() (const json_spirit::Array& params, bool fHelp);
+
+};
+
 #endif // NAMEGETRPC_H


### PR DESCRIPTION
This implements name_scan in libcoin.  As discussed on the forum (https://forum.namecoin.info/viewtopic.php?f=2&t=1917), it does not return the names in the same order as namecoind.  But this does not change the ability to enumerate all names with it.

Please test if you can, but do not merge here - I will try to get Michael to merge upstream to libcoin/libcoin.
